### PR TITLE
Fixing conflicting stack sizes with openblas

### DIFF
--- a/configure
+++ b/configure
@@ -3338,18 +3338,6 @@ if test "x$use_pthread_stack_min" = xno; then
 fi
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if R is using openblas" >&5
-$as_echo_n "checking if R is using openblas... " >&6; }
-BLAS_LIBS=`"${R_HOME}/bin/R" CMD config BLAS_LIBS`
-if echo "${BLAS_LIBS}" | grep openblas > /dev/null; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: openblas found. preprocessCore threading will be disabled" >&5
-$as_echo "openblas found. preprocessCore threading will be disabled" >&6; }
-    use_pthreads=no
-else
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: openblas not found. preprocessCore threading will not be disabled" >&5
-$as_echo "openblas not found. preprocessCore threading will not be disabled" >&6; }
-fi
-
 
 # Check whether --enable-threading was given.
 if test "${enable_threading+set}" = set; then :

--- a/configure.in
+++ b/configure.in
@@ -55,14 +55,6 @@ if test "x$use_pthread_stack_min" = xno; then
 fi
 
 
-AC_MSG_CHECKING([if R is using openblas])
-BLAS_LIBS=`"${R_HOME}/bin/R" CMD config BLAS_LIBS`
-if echo "${BLAS_LIBS}" | grep openblas > /dev/null; then
-    AC_MSG_RESULT([openblas found. preprocessCore threading will be disabled])
-    use_pthreads=no
-else
-    AC_MSG_RESULT([openblas not found. preprocessCore threading will not be disabled])
-fi
 
 
 AC_ARG_ENABLE([threading],

--- a/src/R_subColSummarize.c
+++ b/src/R_subColSummarize.c
@@ -54,6 +54,16 @@ struct loop_data{
   int start_row;
   int end_row;
 };
+
+#ifdef __linux__
+#include <features.h>
+#ifdef __GLIBC__
+#ifdef __GLIBC_PREREQ && __GLIBC_PREREQ(2, 15)
+#define INFER_MIN_STACKSIZE 1
+#endif
+#endif
+#endif
+
 #endif
 
 
@@ -108,11 +118,17 @@ SEXP R_subColSummarize_avg_log(SEXP RMatrix, SEXP R_rowIndexList){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status;
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -136,8 +152,7 @@ SEXP R_subColSummarize_avg_log(SEXP RMatrix, SEXP R_rowIndexList){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   /* this code works out how many threads to use and allocates ranges of subColumns to each thread */
@@ -276,11 +291,17 @@ SEXP R_subColSummarize_log_avg(SEXP RMatrix, SEXP R_rowIndexList){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status; 
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -304,8 +325,7 @@ SEXP R_subColSummarize_log_avg(SEXP RMatrix, SEXP R_rowIndexList){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   
@@ -447,11 +467,17 @@ SEXP R_subColSummarize_avg(SEXP RMatrix, SEXP R_rowIndexList){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status; 
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -475,8 +501,7 @@ SEXP R_subColSummarize_avg(SEXP RMatrix, SEXP R_rowIndexList){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   
@@ -619,11 +644,17 @@ SEXP R_subColSummarize_biweight_log(SEXP RMatrix, SEXP R_rowIndexList){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status;
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -648,8 +679,7 @@ SEXP R_subColSummarize_biweight_log(SEXP RMatrix, SEXP R_rowIndexList){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   /* this code works out how many threads to use and allocates ranges of subColumns to each thread */
@@ -790,11 +820,17 @@ SEXP R_subColSummarize_biweight(SEXP RMatrix, SEXP R_rowIndexList){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status;
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -818,8 +854,7 @@ SEXP R_subColSummarize_biweight(SEXP RMatrix, SEXP R_rowIndexList){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   
@@ -962,11 +997,17 @@ SEXP R_subColSummarize_median_log(SEXP RMatrix, SEXP R_rowIndexList){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status;
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -990,8 +1031,7 @@ SEXP R_subColSummarize_median_log(SEXP RMatrix, SEXP R_rowIndexList){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   
@@ -1132,11 +1172,17 @@ SEXP R_subColSummarize_log_median(SEXP RMatrix, SEXP R_rowIndexList){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status; 
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -1160,8 +1206,7 @@ SEXP R_subColSummarize_log_median(SEXP RMatrix, SEXP R_rowIndexList){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   
@@ -1301,11 +1346,17 @@ SEXP R_subColSummarize_median(SEXP RMatrix, SEXP R_rowIndexList){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status; 
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -1329,8 +1380,7 @@ SEXP R_subColSummarize_median(SEXP RMatrix, SEXP R_rowIndexList){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   
@@ -1475,11 +1525,17 @@ SEXP R_subColSummarize_medianpolish_log(SEXP RMatrix, SEXP R_rowIndexList){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status; 
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -1507,8 +1563,7 @@ SEXP R_subColSummarize_medianpolish_log(SEXP RMatrix, SEXP R_rowIndexList){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   
@@ -1650,11 +1705,17 @@ SEXP R_subColSummarize_medianpolish(SEXP RMatrix, SEXP R_rowIndexList){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status; 
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -1678,8 +1739,7 @@ SEXP R_subColSummarize_medianpolish(SEXP RMatrix, SEXP R_rowIndexList){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   

--- a/src/R_subrcModel_interfaces.c
+++ b/src/R_subrcModel_interfaces.c
@@ -51,6 +51,16 @@ struct loop_data{
   int start_row;
   int end_row;
 };
+
+#ifdef __linux__
+#include <features.h>
+#ifdef __GLIBC__
+#ifdef __GLIBC_PREREQ && __GLIBC_PREREQ(2, 15)
+#define INFER_MIN_STACKSIZE 1
+#endif
+#endif
+#endif
+
 #endif
 
 
@@ -165,11 +175,17 @@ SEXP R_sub_rcModelSummarize_medianpolish(SEXP RMatrix, SEXP R_rowIndexList){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status; 
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -211,8 +227,7 @@ SEXP R_sub_rcModelSummarize_medianpolish(SEXP RMatrix, SEXP R_rowIndexList){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   
@@ -480,11 +495,17 @@ SEXP R_sub_rcModelSummarize_plm(SEXP RMatrix, SEXP R_rowIndexList, SEXP PsiCode,
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status; 
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -532,8 +553,7 @@ SEXP R_sub_rcModelSummarize_plm(SEXP RMatrix, SEXP R_rowIndexList, SEXP PsiCode,
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   

--- a/src/qnorm.c
+++ b/src/qnorm.c
@@ -110,6 +110,16 @@ struct loop_data{
   int start_col;
   int end_col;
 };
+
+#ifdef __linux__
+#include <features.h>
+#ifdef __GLIBC__
+#ifdef __GLIBC_PREREQ && __GLIBC_PREREQ(2, 15)
+#define INFER_MIN_STACKSIZE 1
+#endif
+#endif
+#endif
+
 #endif
 
 /*****************************************************************************************************
@@ -486,11 +496,17 @@ int qnorm_c_l(double *data, size_t rows, size_t cols){
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status;
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -510,8 +526,7 @@ int qnorm_c_l(double *data, size_t rows, size_t cols){
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
   
@@ -1597,11 +1612,17 @@ int qnorm_c_using_target_l(double *data, size_t rows, size_t cols, double *targe
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status;
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -1631,9 +1652,7 @@ int qnorm_c_using_target_l(double *data, size_t rows, size_t cols, double *targe
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
 
@@ -1890,11 +1909,17 @@ int qnorm_c_determine_target_l(double *data, size_t rows, size_t cols, double *t
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status;
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -1910,8 +1935,7 @@ int qnorm_c_determine_target_l(double *data, size_t rows, size_t cols, double *t
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
 
@@ -2484,11 +2508,17 @@ int qnorm_c_determine_target_via_subset_l(double *data, size_t rows, size_t cols
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status;
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -2504,8 +2534,7 @@ int qnorm_c_determine_target_via_subset_l(double *data, size_t rows, size_t cols
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
 
@@ -2988,11 +3017,17 @@ int qnorm_c_using_target_via_subset_l(double *data, size_t rows, size_t cols, in
   double chunk_size_d, chunk_tot_d;
   char *nthreads;
   pthread_attr_t attr;
+  /* Initialize thread attribute */
+  pthread_attr_init(&attr);
   pthread_t *threads;
   struct loop_data *args;
   void *status;
 #ifdef PTHREAD_STACK_MIN
-  size_t stacksize = PTHREAD_STACK_MIN + 0x4000;
+#ifdef INFER_MIN_STACKSIZE
+  size_t stacksize = __pthread_get_minstack(&attr) + sysconf(_SC_PAGE_SIZE);
+#else
+  size_t stacksize = PTHREAD_STACK_MIN + sysconf(_SC_PAGE_SIZE);
+#endif
 #else
   size_t stacksize = 0x8000;
 #endif
@@ -3022,9 +3057,7 @@ int qnorm_c_using_target_via_subset_l(double *data, size_t rows, size_t cols, in
   }
   threads = (pthread_t *) Calloc(num_threads, pthread_t);
 
-  /* Initialize and set thread detached attribute */
-
-  pthread_attr_init(&attr);
+  /* Set thread detached attribute */
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_setstacksize (&attr, stacksize);
 


### PR DESCRIPTION
This is a fix to enable threads on Linux-glibc-openblas-based installations, which affects the issue described in https://github.com/bmbolstad/preprocessCore/issues/1. Apparently the use of TLS in openblas makes the PTHREADS_STACK_MIN value useless, since glibc does not update its value and threads are expected to use extra stack capacity.