### PR TITLE
do not define mutex_R multiple times

### DIFF
--- a/src/R_subColSummarize.c
+++ b/src/R_subColSummarize.c
@@ -37,13 +37,13 @@
 #include "median.h"
 
 #include "medianpolish.h"
+#include "common.h"
 
 #ifdef USE_PTHREADS
 #include <pthread.h>
 #include <limits.h>
 #include <unistd.h>
 #define THREADS_ENV_VAR "R_THREADS"
-pthread_mutex_t mutex_R;
 struct loop_data{
   double *matrix;
   double *results;

--- a/src/R_subrcModel_interfaces.c
+++ b/src/R_subrcModel_interfaces.c
@@ -26,7 +26,7 @@
 #include "rlm_se.h"
 #include "psi_fns.h"
 #include "medianpolish.h"
-
+#include "common.h"
 
 
 
@@ -37,7 +37,6 @@
 #include <limits.h>
 #include <unistd.h>
 #define THREADS_ENV_VAR "R_THREADS"
-pthread_mutex_t mutex_R;
 struct loop_data{
   double *matrix;
   SEXP *R_return_value;

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,9 @@
+#ifndef COMMON_H
+#define COMMON_H 1
+
+#ifdef USE_PTHREADS
+#include <pthread.h>
+extern pthread_mutex_t mutex_R;
+#endif
+
+#endif

--- a/src/rma_background4.c
+++ b/src/rma_background4.c
@@ -44,13 +44,13 @@
 
 #include "weightedkerneldensity.h"
 #include "rma_background4.h"
+#include "common.h"
 
 #ifdef USE_PTHREADS
 #include <pthread.h>
 #include <limits.h>
 #include <unistd.h>
 #define THREADS_ENV_VAR "R_THREADS"
-pthread_mutex_t mutex_R;
 struct loop_data{
   double *data;
   size_t rows;


### PR DESCRIPTION
preprocessCore stopped building from source in Fedora rawhide as a result of moving to GCC 10. GCC 10 sets -fno-common by default, which means that variables with the same name should not be defined in multiple places in a combined code base.

In preprocessCore, "mutex_R" is defined in several places. This pull request removes the mutex_R definition from every .c file (except qnorm.c), creates a common.h which has an extern definition of mutex_R, and then #includes the common.h in all of the .c files where mutex_R was removed.

I have tested this locally and confirm that this fix resolves the build failure.