### PR TITLE
Add option to preserve matrix row and column names when quantile normalizing

### DIFF
--- a/R/normalize.quantiles.R
+++ b/R/normalize.quantiles.R
@@ -28,7 +28,7 @@
 ##
 ##################################################################
 
-normalize.quantiles <- function(x,copy=TRUE){
+normalize.quantiles <- function(x,copy=TRUE,keep.names=FALSE){
 
   rows <- dim(x)[1]
   cols <- dim(x)[2]
@@ -45,11 +45,16 @@ normalize.quantiles <- function(x,copy=TRUE){
   #matrix(.C("qnorm_c", as.double(as.vector(x)), as.integer(rows), as.integer(cols))[[1]], rows, cols)
 
 ##  .Call("R_qnorm_c",x,copy, PACKAGE="preprocessCore");
-  .Call("R_qnorm_c_handleNA",x,copy, PACKAGE="preprocessCore");
+  mat <- .Call("R_qnorm_c_handleNA",x,copy, PACKAGE="preprocessCore");
+  if(keep.names){
+    rownames(mat) <- rownames(x)
+    colnames(mat) <- colnames(x)
+  }
+  mat
 }
 
 
-normalize.quantiles.robust <- function(x,copy=TRUE,weights=NULL,remove.extreme=c("variance","mean","both","none"),n.remove=1,use.median=FALSE,use.log2=FALSE){
+normalize.quantiles.robust <- function(x,copy=TRUE,weights=NULL,remove.extreme=c("variance","mean","both","none"),n.remove=1,use.median=FALSE,use.log2=FALSE,keep.names=FALSE){
 
   calc.var.ratios <- function(x){
     cols <- dim(x)[2]
@@ -104,5 +109,9 @@ normalize.quantiles.robust <- function(x,copy=TRUE,weights=NULL,remove.extreme=c
     }
   }
   
-  .Call("R_qnorm_robust_c",x,copy,weights,as.integer(use.median),as.integer(use.log2),as.integer(use.huber),PACKAGE="preprocessCore")
+  mat <- .Call("R_qnorm_robust_c",x,copy,weights,as.integer(use.median),as.integer(use.log2),as.integer(use.huber),PACKAGE="preprocessCore")
+  if(keep.names){
+    rownames(mat) <- rownames(x)
+    colnames(mat) <- colnames(x)
+  }
 }

--- a/man/normalize.quantiles.Rd
+++ b/man/normalize.quantiles.Rd
@@ -14,6 +14,8 @@
   \item{copy}{Make a copy of matrix before normalizing. Usually safer to
     work with a copy, but in certain situations not making a copy of the
     matrix, but instead normalizing it in place will be more memory friendly.}
+  \item{keep.names}{Boolean option to preserve matrix row and column names in
+    output.}
 }
 \details{This method is based upon the concept of a quantile-quantile
   plot extended to n dimensions. No special allowances are made for

--- a/man/normalize.quantiles.robust.Rd
+++ b/man/normalize.quantiles.robust.Rd
@@ -23,6 +23,8 @@
     chip, otherwise uses a weighted mean}
   \item{use.log2}{work on log2 scale. This means we will be using the
     geometric mean rather than ordinary mean}
+  \item{keep.names}{Boolean option to preserve matrix row and column names in
+    output.}
 }
 \details{This method is based upon the concept of a quantile-quantile 
   plot extended to n dimensions. Note that the matrix is of intensities

--- a/tests/qnormtest.R
+++ b/tests/qnormtest.R
@@ -51,4 +51,13 @@ if (all(abs(normalize.quantiles.use.target(y,y.norm.target.truth) - y.norm.truth
 }
 
 
-
+x <- matrix(c(100,15,200,250,110,16.5,220,275,120,18,240,300),ncol=3)
+rownames(x) <- letters[1:4]
+colnames(x) <- LETTERS[1:3]
+y <- normalize.quantiles(x, keep.names = TRUE)
+if(!all(colnames(x)==colnames(y))){
+    stop("Disagreement between initial and final column names despite keep.names=TRUE")
+}
+if(!all(rownames(x)==rownames(y))){
+    stop("Disagreement between initial and final row names despite keep.names=TRUE")
+}


### PR DESCRIPTION
Hi, great package that I've been using for a while. One quality-of-life thing that I've finally decided to help with is preserving row and column names after normalization - these are currently dropped. My workflow typically keeps some information there, so replacing that every time is a bit of a pain. This PR adds an option to `normalize.quantiles` and `normalize.quantiles.robust` that allows the user to specify that the row and column names should be preserved after normalization (`keep.names`). The default behavior is preserved by setting the default `keep.names=FALSE`. I've added a simple unit test and updated the documentation as well, but wasn't able to run an `R CMD check` on my machine so I can't guarantee that it'll pass checks.