### PR TITLE
fixed small bug in 'normalize.quantiles.robust'

### DIFF
--- a/R/normalize.quantiles.R
+++ b/R/normalize.quantiles.R
@@ -114,4 +114,5 @@ normalize.quantiles.robust <- function(x,copy=TRUE,weights=NULL,remove.extreme=c
     rownames(mat) <- rownames(x)
     colnames(mat) <- colnames(x)
   }
+  mat
 }


### PR DESCRIPTION
I noticed a very small bug in the code that breaks `normalize.quantiles.robust` (see https://github.com/rformassspectrometry/QFeatures/pull/139 for background). Here is a reproducible example:

```r
x <- matrix(rnorm(100), 10, 10)
normalize.quantiles(x)
## returns a 10 by 10 matrix (as expected)
normalize.quantiles.robust(x)
## returns NULL
```
The bug was inserted during commit e6ff3f786152d939cde82783237a3673686eb09a
This small PR solves the issue. 