### PR TITLE
Add missing mat return value.

### DIFF
--- a/R/normalize.quantiles.R
+++ b/R/normalize.quantiles.R
@@ -114,4 +114,5 @@ normalize.quantiles.robust <- function(x,copy=TRUE,weights=NULL,remove.extreme=c
     rownames(mat) <- rownames(x)
     colnames(mat) <- colnames(x)
   }
+  mat
 }


### PR DESCRIPTION
Here's a simple reproducible example.

```r
library(SummarizedExperiment)
example(SummarizedExperiment)
se0

library(preprocessCore)
packageVersion("preprocessCore") ## 1.55.0
normalize.quantiles(assay(se0)) ## OK
normalize.quantiles.robust(assay(se0)) ## OK


BiocManager::install("preprocessCore")
library(preprocessCore)
packageVersion("preprocessCore") ## 1.55.1
normalize.quantiles(assay(se0)) ## OK
normalize.quantiles.robust(assay(se0)) ## NULL
```
